### PR TITLE
Move fejs import to place of usage

### DIFF
--- a/hardhat-fe/src/compilation.ts
+++ b/hardhat-fe/src/compilation.ts
@@ -3,7 +3,6 @@ import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { Artifact, Artifacts, ProjectPathsConfig } from "hardhat/types";
 import { localPathToSourceName } from "hardhat/utils/source-names";
 import path from "path";
-var fejs = require("@berlinvege/fejs");
 import * as fs from "fs";
 import { FeConfig } from "./types";
 
@@ -100,6 +99,7 @@ export async function compile(
       compileFileWithFeBinary(file);
       compilerResult = getCompileResultFromBinaryBuild();
     } else {
+      var fejs = require("@berlinvege/fejs");
       console.log("Compiling with Fejs...");
       compilerResult = fejs.compile(feSourceCode);
     }


### PR DESCRIPTION
Importing `fejs` causes a crash on my machine.

```
$ npx hardhat compile
Nothing to compile
An unexpected error occurred:

Error: /home/cburgdorf/Documents/hacking/ef/fe15puzzle/node_modules/@berlinvege/fejs/index.node: undefined symbol: _ZN2v816FunctionTemplate3NewEPNS_7IsolateEPFvRKNS_20FunctionCallbackInfoINS_5ValueEEEENS_5LocalIS4_EENSA_INS_9SignatureEEEiNS_19ConstructorBehaviorENS_14SideEffectTypeEPKNS_9CFunctionE
    at Object.Module._extensions..node (internal/modules/cjs/loader.js:1057:18)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/home/cburgdorf/Documents/hacking/ef/fe15puzzle/node_modules/@berlinvege/hardhat-fe/src/compilation.ts:6:12)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
npm ERR! code 1
npm ERR! path /home/cburgdorf/Documents/hacking/ef/fe15puzzle
npm ERR! command failed
npm ERR! command sh -c hardhat "compile"
```

To mitigate that I moved the import further down to its usage place so that I can run the plugin using the local fe binary instead.